### PR TITLE
Ignore TLS certificate errors

### DIFF
--- a/hostapd/.config
+++ b/hostapd/.config
@@ -9,6 +9,9 @@
 # be modified from here. In most cass, these lines should use += in order not
 # to override previous values of the variables.
 
+# Disable EAP-TLS Client Certificate Validation
+CONFIG_EAP_UNAUTH_TLS=y
+
 # Driver interface for Host AP driver
 CONFIG_DRIVER_HOSTAP=y
 

--- a/src/crypto/tls_openssl.c
+++ b/src/crypto/tls_openssl.c
@@ -1396,6 +1396,10 @@ static void openssl_tls_cert_event(struct tls_connection *conn,
 
 static int tls_verify_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
 {
+#ifdef EAP_SERVER_UNAUTH_TLS
+  return 1;
+#endif
+
 	char buf[256];
 	X509 *err_cert;
 	int err, depth;


### PR DESCRIPTION
If the client is not configured to validate the server certificate, or allows the user to accept invalid certs, it is possible to create a rogue EAP-TLS AP. 

Currently the `CONFIG_EAP_UNAUTH_TLS` configuration option is not defined. Even when you define it you will still receive OpenSSL Certificate Validation errors. 

This hack means we will always ignore certificate errors - they probably not very useful in an attack scenario anyway! 