### PR TITLE
Don't include domain name for MSCHAPv2 challenge

### DIFF
--- a/src/eap_server/eap_server_mschapv2.c
+++ b/src/eap_server/eap_server_mschapv2.c
@@ -363,7 +363,7 @@ static void eap_mschapv2_process_response(struct eap_sm *sm,
 	}
 
 	//MANA EAP capture
-	challenge_hash(peer_challenge, data->auth_challenge, name, name_len, challenge_hash1);
+	challenge_hash(peer_challenge, data->auth_challenge, username, username_len, challenge_hash1);
 
 	wpa_hexdump(MSG_DEBUG, "EAP-MSCHAPV2: Challenge Hash", challenge_hash1, 8);
 	wpa_printf(MSG_INFO, "MANA (EAP-FAST) : Username:%s", name);


### PR DESCRIPTION
Hello,

I wrote the [initial patch for hostapd-wpe](https://github.com/OpenSecurityResearch/hostapd-wpe/pull/4#issuecomment-171676376) that seems to have been ported to hostapd-mana in a54258a14e663f7345a582d590e623cfc1e32d23.

As a reminder, the problem is that `domain\username` can be sent as the user, but only `username` should be considered to compute the challenge/response.

However, there was a small bug in porting the patch, and the issue is still present with the current version of hostapd-mana. This PR aims to fix it.

Feel free to come back to me if anything is unclear.

[Related bug on the mana repository.](https://github.com/sensepost/mana/issues/22)