### PR TITLE
Fix potential heap off-by-null bugs

### DIFF
--- a/hostapd/config_file.c
+++ b/hostapd/config_file.c
@@ -2179,7 +2179,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 		}
 		conf->mana_ssid_filter_file = tmp1;
 		wpa_printf(MSG_INFO, "MANA: SSID Filter enabled. File %s set.",tmp1);
-	} else if (os_strcmp(buf, "mana_ssid_preload_file")) {
+	} else if (os_strcmp(buf, "mana_ssid_preload_file") == 0) {
 		struct ssid_filter_entry *ssid_list_ = NULL;
 		int ssid_num_ = 0;
 		if (hostapd_config_read_ssidlist(pos, &ssid_list_, &ssid_num_)) {

--- a/hostapd/config_file.c
+++ b/hostapd/config_file.c
@@ -2159,8 +2159,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 			wpa_printf(MSG_DEBUG, "MANA: MAC ACLs extended to management frames");
 		}
 	} else if (os_strcmp(buf, "mana_outfile") == 0) {
-		char *tmp = malloc(strlen(pos));
-		strcpy(tmp,pos);
+		char *tmp = strdup(pos);
 		FILE *f = fopen(pos, "a");
 		if (!f) {
 			wpa_printf(MSG_ERROR, "MANA: Line %d: Failed to open activity file '%s'", line, pos);
@@ -2170,8 +2169,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 		conf->mana_outfile = tmp;
 		wpa_printf(MSG_INFO, "MANA: Observed activity will be written to. File %s set.",tmp);
 	} else if (os_strcmp(buf, "mana_ssid_filter_file") == 0) {
-		char *tmp1 = malloc(strlen(pos));
-		strcpy(tmp1,pos);
+		char *tmp1 = strdup(pos);
 		if (hostapd_config_read_ssidlist(pos, &bss->ssid_filter,
 					&bss->num_ssid_filter)) {
 			wpa_printf(MSG_ERROR, "Line %d: Failed to read SSID filter list '%s'",
@@ -2187,8 +2185,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 			wpa_printf(MSG_DEBUG, "MANA: WPE EAP mode enabled");
 		}
 	} else if (os_strcmp(buf, "mana_credout") == 0) {
-		char *tmp2 = malloc(strlen(pos));
-		strcpy(tmp2,pos);
+		char *tmp2 = strdup(pos);
 		FILE *f = fopen(pos, "a");
 		if (!f) {
 			wpa_printf(MSG_ERROR, "MANA: Line %d: Failed to open credential out file '%s'", line, pos);
@@ -2198,8 +2195,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 		conf->mana_credout = tmp2;
 		wpa_printf(MSG_INFO, "MANA: Captured credentials will be written to file '%s'.",conf->mana_credout);
 	} else if (os_strcmp(buf, "mana_wpaout") == 0) {
-		char *tmp2 = malloc(strlen(pos));
-		strcpy(tmp2,pos);
+		char *tmp2 = strdup(pos);
 		FILE *f = fopen(pos, "a");
 		if (!f) {
 			wpa_printf(MSG_ERROR, "MANA: Line %d: Failed to open WPA/2 handshake out file '%s'", line, pos);
@@ -2227,8 +2223,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 			wpa_printf(MSG_DEBUG, "SYCOPHANT: Enabled");
 		}
 	} else if (os_strcmp(buf, "sycophant_dir") == 0) {
-		char *tmp = malloc(strlen(pos));
-		strcpy(tmp,pos);
+		char *tmp = strdup(pos);
 		if (access(pos, W_OK) != 0) {
 			wpa_printf(MSG_ERROR, "SYCOPHANT: Line %d: Failed to access sycophant directory '%s'", line, pos);
 			return 1;

--- a/hostapd/config_file.c
+++ b/hostapd/config_file.c
@@ -2189,10 +2189,10 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 		}
 		extern struct mana_ssid *mana_ssidhash;
 		for (int i = 0; i < ssid_num_; i++) {
-			const char *ssid = ssid_list_[i].ssid;
+			char *ssid = ssid_list_[i].ssid;
 			size_t ssid_len = strlen(ssid_list_[i].ssid);
 			struct mana_ssid *newssid = os_malloc(sizeof(struct mana_ssid));
-			os_memcpy(newssid->ssid_txt, wpa_ssid_txt(ssid, ssid_len), ssid_len + 1);
+			os_memcpy(newssid->ssid_txt, wpa_ssid_txt((const u8 *)ssid, ssid_len), ssid_len + 1);
 			os_memcpy(newssid->ssid, ssid, ssid_len);
 			newssid->ssid_len = ssid_len;
 			HASH_ADD_STR(mana_ssidhash, ssid_txt, newssid);

--- a/src/ap/beacon.h
+++ b/src/ap/beacon.h
@@ -11,6 +11,9 @@
 #define BEACON_H
 
 struct ieee80211_mgmt;
+struct hostapd_iface;
+struct hostapd_info;
+struct hostapd_sta_info;
 
 void handle_probe_req(struct hostapd_data *hapd,
 		      const struct ieee80211_mgmt *mgmt, size_t len,

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -423,6 +423,7 @@ void perror(const char *s);
 #define __bitwise __attribute__((bitwise))
 #else
 #define __force
+#undef __bitwise
 #define __bitwise
 #endif
 


### PR DESCRIPTION
Just use `strdup` to replace `malloc` + `strcpy` allocations.